### PR TITLE
Drop need to call 'import pyglotaran_alias' before 'import pyglotaran'

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,9 @@ insert_final_newline = true
 charset = utf-8
 end_of_line = lf
 
+[setup.cfg]
+indent_style = tab
+
 [*.bat]
 indent_style = tab
 end_of_line = crlf

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8
+end_of_line = lf
+
+[*.bat]
+indent_style = tab
+end_of_line = crlf
+
+[.gitattributes]
+indent_style = tab
+
+[*.py]
+indent_size = 4
+
+[LICENSE]
+insert_final_newline = false
+
+[Makefile]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*	text=lf
+*.bat	text eol=crlf

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,27 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: weekly
+      day: friday
+      time: "18:00"
+      timezone: Europe/Amsterdam
+    reviewers:
+      - s-weigand
+      - jsnel
+    assignees:
+      - s-weigand
+      - jsnel
+
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: friday
+      time: "18:00"
+      timezone: Europe/Amsterdam
+    reviewers:
+      - s-weigand
+      - jsnel
+    assignees:
+      - s-weigand
+      - jsnel

--- a/.github/workflows/CI_CD_actions.yml
+++ b/.github/workflows/CI_CD_actions.yml
@@ -41,7 +41,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    needs: [test] # docs
+    needs: [test]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.7
@@ -56,9 +56,8 @@ jobs:
       - name: Build dist
         run: |
           python setup.py sdist bdist_wheel
-      # TODO: needs new token
-      # - name: Publish package
-      #   uses: pypa/gh-action-pypi-publish@master
-      #   with:
-      #     user: __token__
-      #     password: ${{ secrets.pypi_pyglotaran_token }}
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_pyglotaran_alias_token }}

--- a/.github/workflows/autoupdate-pre-commit-config.yml
+++ b/.github/workflows/autoupdate-pre-commit-config.yml
@@ -1,0 +1,33 @@
+name: "Update pre-commit config"
+# You need to set an access token as a secret ACTION_TRIGGER_TOKEN on this repo
+# in order for the PR to trigger the CI.
+# For more details see: https://github.com/technote-space/create-pr-action#github_token
+# If you don't want the PR to trigger the CI (NOT RECOMMENDED), comment out the GITHUB_TOKEN line.
+
+on:
+  schedule:
+    - cron: "0 20 * * 5" # At 20:00 on each Friday.
+  workflow_dispatch:
+
+jobs:
+  update-pre-commit:
+    name: Autoupdate pre-commit config
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v2
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-autoupdate
+      - name: Update pre-commit config packages
+        uses: technote-space/create-pr-action@v2
+        with:
+          GITHUB_TOKEN: ${{ secrets.ACTION_TRIGGER_TOKEN }}
+          EXECUTE_COMMANDS: |
+            pip install pre-commit
+            pre-commit autoupdate || (exit 0);
+            pre-commit run -a || (exit 0);
+          COMMIT_MESSAGE: "⬆️ UPGRADE: Autoupdate pre-commit config"
+          PR_BRANCH_NAME: "pre-commit-config-update-${PR_ID}"
+          PR_TITLE: "⬆️ UPGRADE: Autoupdate pre-commit config"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       - id: black
         language_version: python3
   - repo: https://github.com/PyCQA/isort
-    rev: 5.5.1
+    rev: 5.5.4
     hooks:
       - id: isort
   - repo: https://gitlab.com/pycqa/flake8
@@ -34,5 +34,5 @@ repos:
     rev: v1.17.1
     hooks:
       - id: codespell
-        files: ".py|.rst"
+        files: ".py|.rst|.md"
         args: [-L doas]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     hooks:
       - id: black
         language_version: python3
-  - repo: https://github.com/timothycrosley/isort
+  - repo: https://github.com/PyCQA/isort
     rev: 5.5.1
     hooks:
       - id: isort

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ at times one might be tempted to use `import pyglotaran` instead of `import glot
 ## Usage
 
 ```python
-import pyglotaran_alias
 import pyglotaran
+from pyglotaran import
 
 ```

--- a/README.md
+++ b/README.md
@@ -9,6 +9,39 @@ at times one might be tempted to use `import pyglotaran` instead of `import glot
 
 ```python
 import pyglotaran
-from pyglotaran import
-
 ```
+
+Or
+
+```python
+from pyglotaran import ParameterGroup
+```
+
+For autocompletion to work in an interactive session (i.e. `python repl`, `jupyter-console` or `jupyter-notebooks`) you need to first import the `pyglotaran-alias` i.e. with `import pyglotaran`.
+After this is done `glotaran` is registered under the alias `pyglotaran`, and autocomplete should work.
+
+## How does it work?
+
+When you use `import pyglotaran` the following happens:
+
+- `pyglotaran-alias`'s [`__init__.py`](https://github.com/s-weigand/pyglotaran-alias/blob/master/pyglotaran/__init__.py) is called.
+- The module cache (`sys.modules`) is populated with all `glotaran` modules.
+- For each `glotaran` module an additional corresponding entry with `pyglotaran` is added to the module cache.
+- The local variables used modify the module cache are deleted, so they won't pollute your globals.
+- The `pyglotaran` global variable replaces [itself](https://github.com/s-weigand/pyglotaran-alias/blob/master/pyglotaran/__init__.py) with the `glotaran` package.
+
+## Known problems
+
+### Linter shows error "No name '`<module or attribute name>`' in module '`pyglotaran`'"
+
+Since most linters use a static file analysis, they won't understand the live swapping of modules and think that `pyglotaran` is defined in[`pyglotaran-alias`](https://github.com/s-weigand/pyglotaran-alias/blob/master/pyglotaran/__init__.py), where `<module or attribute name>` most likely doesn't exist.
+Thus you have a `Schrödinger-Linter`, which is right and wrong at the same time.
+
+### Autocomplete doesn't work, when using a text editor
+
+This is due to the fact that autocomplete engines (similar to linters) use a static file analysis and thus think that `pyglotaran` is defined in [`pyglotaran-alias`](https://github.com/s-weigand/pyglotaran-alias/blob/master/pyglotaran/__init__.py). Sadly I didn't find a way to fix this issue yet, since it also strongly depends on the used autocomplete engine.
+
+### Autocomplete in interactive session shows attributes on `pyglotaran` which aren't part of `glotaran`
+
+When using an interactive session (i.e. `python repl`, `jupyter-console` or `jupyter-notebooks`), the autocomplete will pick up the replaced module and allow you to get autocompletion for modules and attributes defined in `glotaran`.
+But due to static file analysis it will also pick up modules and attributes defined in [`pyglotaran-alias`](https://github.com/s-weigand/pyglotaran-alias/blob/master/pyglotaran/__init__.py)

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ When you use `import pyglotaran` the following happens:
 
 ## Known problems
 
-### Linter shows error "No name '`<module or attribute name>`' in module '`pyglotaran`'"
+### Linter shows error "No name '`<module or attribute name>`' in module '`pyglotaran`'", when using a text editor
 
-Since most linters use a static file analysis, they won't understand the live swapping of modules and think that `pyglotaran` is defined in[`pyglotaran-alias`](https://github.com/s-weigand/pyglotaran-alias/blob/master/pyglotaran/__init__.py), where `<module or attribute name>` most likely doesn't exist.
+Since most linters use a static file analysis, they won't understand the live swapping of modules at runtime and think that `pyglotaran` is defined in[`pyglotaran-alias`](https://github.com/s-weigand/pyglotaran-alias/blob/master/pyglotaran/__init__.py), where `<module or attribute name>` most likely doesn't exist.
 Thus you have a `Schrödinger-Linter`, which is right and wrong at the same time.
 
 ### Autocomplete doesn't work, when using a text editor

--- a/pyglotaran/__init__.py
+++ b/pyglotaran/__init__.py
@@ -2,8 +2,6 @@
 import sys
 from importlib.util import find_spec
 
-__version__ = "0.0.1"
-
 if find_spec("glotaran") and "pyglotaran" not in globals().keys():
     __import__("glotaran")
 

--- a/pyglotaran/__init__.py
+++ b/pyglotaran/__init__.py
@@ -2,6 +2,8 @@
 import sys
 from importlib.util import find_spec
 
+__version__ = "0.0.1"
+
 if find_spec("glotaran") and "pyglotaran" not in globals().keys():
     __import__("glotaran")
 

--- a/pyglotaran/__init__.py
+++ b/pyglotaran/__init__.py
@@ -1,9 +1,8 @@
 """Enables 'import pyglotaran' as well as the default 'import glotaran'."""
-
 import sys
 from importlib.util import find_spec
 
-if find_spec("glotaran"):
+if find_spec("glotaran") and "pyglotaran" not in globals().keys():
     __import__("glotaran")
 
     modules_to_update = {}
@@ -11,6 +10,13 @@ if find_spec("glotaran"):
         if fullname == "glotaran" or fullname.startswith("glotaran."):
             modules_to_update[f"py{fullname}"] = glotaran_module
     sys.modules.update(modules_to_update)
+    pyglotaran = sys.modules["glotaran"]
+    # ensure that variables used here aren't visible in autocomplete
+    del locals()["sys"]
+    del locals()["find_spec"]
+    del locals()["fullname"]
+    del locals()["glotaran_module"]
+    del locals()["modules_to_update"]
 else:
     raise ImportError(
         """'pyglotaran_alias' only provides an alias to 'import glotaran' with 'import pyglotaran'.

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ wheel>=0.30.0
 bump2version>=0.5.11
 
 # glotaran setup dependencies
-pyglotaran
+pyglotaran==0.1.0
 
 
 # testing dependencies

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,9 +2,6 @@
 pip>=18.0
 wheel>=0.30.0
 
-# needed to release new versions
-bump2version>=0.5.11
-
 # glotaran setup dependencies
 pyglotaran==0.1.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ classifiers =
     Topic :: Scientific/Engineering :: Chemistry
 
 [options]
-py_modules = pyglotaran_alias
+packages=find:
 python_requires = >=3.6
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ classifiers =
 	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: Implementation :: CPython
-	Programming Language :: Python :: Implementation :: PyPy
 	Topic :: Scientific/Engineering
 	Topic :: Scientific/Engineering :: Physics
 	Topic :: Scientific/Engineering :: Chemistry

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ tag = True
 [metadata]
 name = pyglotaran-alias
 version = 0.0.1
-description = Convenience module which allows to use pyglotaran as alias in the CLI and imports
+description = Convenience module, which allows to use pyglotaran as alias in the CLI and imports
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/s-weigand/pyglotaran-alias

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,11 @@ classifiers =
 	Topic :: Scientific/Engineering
 	Topic :: Scientific/Engineering :: Physics
 	Topic :: Scientific/Engineering :: Chemistry
+project_urls =
+	Core-Project = https://github.com/glotaran/pyglotaran
+	Source = https://github.com/s-weigand/pyglotaran-alias
+	Tracker = https://github.com/s-weigand/pyglotaran-alias/issues
+
 
 [options]
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,32 +1,45 @@
+[bumpversion]
+current_version = 0.0.1
+commit = True
+tag = True
+
 [metadata]
 name = pyglotaran-alias
-version = 0.1.0
+version = 0.0.1
 description = Convenience module which allows to use pyglotaran as alias in the CLI and imports
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/s-weigand/pyglotaran-alias
-author=Sebastian Weigand
-author_email=s.weigand.phy@gmail.com
-license=Apache Software License 2.0
+author = Sebastian Weigand
+author_email = s.weigand.phy@gmail.com
+license = Apache Software License 2.0
 license_file = LICENSE
 classifiers =
-    Development Status :: 4 - Beta
-    License :: OSI Approved :: Apache Software License
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: Implementation :: CPython
-    Programming Language :: Python :: Implementation :: PyPy
-    Topic :: Scientific/Engineering
-    Topic :: Scientific/Engineering :: Physics
-    Topic :: Scientific/Engineering :: Chemistry
+	Development Status :: 4 - Beta
+	License :: OSI Approved :: Apache Software License
+	Programming Language :: Python :: 3
+	Programming Language :: Python :: 3 :: Only
+	Programming Language :: Python :: 3.6
+	Programming Language :: Python :: 3.7
+	Programming Language :: Python :: 3.8
+	Programming Language :: Python :: Implementation :: CPython
+	Programming Language :: Python :: Implementation :: PyPy
+	Topic :: Scientific/Engineering
+	Topic :: Scientific/Engineering :: Physics
+	Topic :: Scientific/Engineering :: Chemistry
 
 [options]
-packages=find:
+packages = find:
 python_requires = >=3.6
 
 [options.entry_points]
 console_scripts =
-    pyglotaran = glotaran.cli.main:glotaran
+	pyglotaran = glotaran.cli.main:glotaran
+
+[bumpversion:file:setup.cfg]
+search = version = "{current_version}"
+replace = version = "{new_version}"
+
+[bumpversion:file:pyglotaran/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,3 @@
-[bumpversion]
-current_version = 0.0.1
-commit = True
-tag = True
-
 [metadata]
 name = pyglotaran-alias
 version = 0.0.1
@@ -39,11 +34,3 @@ python_requires = >=3.6
 [options.entry_points]
 console_scripts =
 	pyglotaran = glotaran.cli.main:glotaran
-
-[bumpversion:file:setup.cfg]
-search = version = "{current_version}"
-replace = version = "{new_version}"
-
-[bumpversion:file:pyglotaran/__init__.py]
-search = __version__ = "{current_version}"
-replace = __version__ = "{new_version}"

--- a/tests/test_pyglotaran_alias.py
+++ b/tests/test_pyglotaran_alias.py
@@ -44,6 +44,8 @@ def test_import_works():
 
     import pyglotaran  # noqa:  F401
 
+    assert hasattr(pyglotaran, "__version__")
+
     assert glotaran.__version__ == pyglotaran.__version__
 
     loaded_module_names = sys.modules.keys()


### PR DESCRIPTION
- `import pyglotaran` works out of the box
- Improved documentation, to explain how it works and what know issues are
- Added more useful tooling
- Removed package `__version__` property, since it gets overwritten anyway
- Removed `bump2version` since it doesn't work with `setup.cfg`
- Added `pre-commit` autoupdate workflow
- Removed claimed support for pypy since it is not tested
- Added python to dependabot config

Same as #3 but not accidentally merged 😿 