### PR TITLE
Prevent pre-commit autoupdate workflow to run on forks

### DIFF
--- a/.github/workflows/autoupdate-pre-commit-config.yml
+++ b/.github/workflows/autoupdate-pre-commit-config.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   update-pre-commit:
+    if: github.repository_owner == 'glotaran'
     name: Autoupdate pre-commit config
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Using github.repository_owner instead of github.repository, allows using the workflow in other repositories of the same organization/user, while preventing it form running on forks.