### PR TITLE
Use the pyglotaran package as cli entrypoint

### DIFF
--- a/.github/workflows/CI_CD_actions.yml
+++ b/.github/workflows/CI_CD_actions.yml
@@ -34,9 +34,12 @@ jobs:
           python -m pip install -r requirements_dev.txt
       - name: Show installed packages
         run: pip freeze
-      - name: Run tests
-        run: |
-          pytest
+      - name: Run unit tests
+        run: pytest tests/test_pyglotaran_alias.py
+      - name: Uninstall pyglotaran
+        run: pip uninstall pyglotaran -y
+      - name: Test cli exception
+        run: pytest tests/test_cli_exception.py
 
   deploy:
     runs-on: ubuntu-latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,4 +33,4 @@ python_requires = >=3.6
 
 [options.entry_points]
 console_scripts =
-	pyglotaran = glotaran.cli.main:glotaran
+	pyglotaran = pyglotaran.cli.main:glotaran

--- a/tests/test_cli_exception.py
+++ b/tests/test_cli_exception.py
@@ -8,3 +8,4 @@ def test_cli_raises_proper_exeption():
         "pyglotaran", shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE
     )
     assert re.search(b"'pip install pyglotaran'", output.stderr) is not None
+    assert output.stdout == b""

--- a/tests/test_cli_exception.py
+++ b/tests/test_cli_exception.py
@@ -1,0 +1,10 @@
+import re
+import subprocess
+
+
+def test_cli_raises_proper_exeption():
+    """Test that cli Raises proper exception when pyglotaran isn't installed."""
+    output = subprocess.run(
+        "pyglotaran", shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE
+    )
+    assert re.search(b"'pip install pyglotaran'", output.stderr) is not None

--- a/tests/test_pyglotaran_alias.py
+++ b/tests/test_pyglotaran_alias.py
@@ -1,4 +1,6 @@
 import importlib.util
+import re
+import subprocess
 import sys
 
 import pytest
@@ -32,6 +34,7 @@ def test_glotaran_import_not_leeking_out():
     ],
 )
 def test_pyglotaran_alias_local_variables_leeking_out(pyglotaran_alias_local_variable):
+    """Test that local variables are removed."""
     assert pyglotaran_alias_local_variable not in locals().keys()
     assert pyglotaran_alias_local_variable not in globals().keys()
     with pytest.raises(ImportError):
@@ -71,8 +74,20 @@ def test_import_works():
 
 
 def test_from_import_works():
+    """Test that from imports work."""
     import glotaran  # noqa:  F401
 
     from pyglotaran import read_model_from_yml
 
     assert glotaran.read_model_from_yml.__code__ == read_model_from_yml.__code__
+
+
+def test_cli_raises_proper_exeption():
+    """Test that the cli alias works properly."""
+    output = subprocess.run(
+        "pyglotaran", shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE
+    )
+    assert (
+        re.search(br"Usage\: pyglotaran \[OPTIONS\] COMMAND \[ARGS\]", output.stdout) is not None
+    )
+    assert output.stderr == b""

--- a/tox.ini
+++ b/tox.ini
@@ -17,5 +17,8 @@ passenv = *
 usedevelop = True
 install_command = {envpython} -m pip install {opts} {packages}
 deps = -r{toxinidir}/requirements_dev.txt
+commands_pre= pip install pyglotaran
 commands =
-    py.test
+  pytest tests/test_pyglotaran_alias.py
+  pip uninstall pyglotaran -y
+  pytest tests/test_cli_exception.py


### PR DESCRIPTION
This way the `__init__.py` of `pyglotaran-alias` will be called and if `pyglotaran` isn't installed, it will raise the proper `ImportError`, telling users to install `pyglotaran`.